### PR TITLE
feat: add a new pipeline for IMF GB inflation rate

### DIFF
--- a/examples/imf_data/.env_template
+++ b/examples/imf_data/.env_template
@@ -1,0 +1,1 @@
+CONNECTOR="csv:/tmp/truflation"

--- a/examples/imf_data/imf_gb_pipeline.py
+++ b/examples/imf_data/imf_gb_pipeline.py
@@ -11,35 +11,7 @@ from truflation.data.source_details import SourceDetails
 load_dotenv()
 
 # Name
-pipeline_name = "IMF GB Inflation"
-
-
-def pre_ingestion_function():
-    """
-    Function to perform operations before the data ingestion phase.
-    This function is called during the pipeline execution before data loading starts.
-
-    Currently, this function only prints out a simple message.
-
-    Returns
-    -------
-    None
-    """
-    print(f'I do this before ingestion')
-
-
-def post_ingestion_function():
-    """
-    Function to perform operations after the data ingestion phase.
-    This function is called during the pipeline execution after all data loading is finished.
-
-    Currently, this function only prints out a simple message.
-
-    Returns
-    -------
-    None
-    """
-    print(f'I do this after ingestion')
+PIPELINE_NAME = "IMF GB Inflation"
 
 
 def parse_imf_data(json_obj: Dict) -> Dict:
@@ -50,8 +22,7 @@ def parse_imf_data(json_obj: Dict) -> Dict:
     Returns:
         pd.DataFrame: Parsed dataframe from json.
     """
-    print(2)
-    return json_obj['CompactData']['DataSet']['Series']
+    return json_obj["CompactData"]["DataSet"]["Series"]
 
 
 sources = [
@@ -59,7 +30,7 @@ sources = [
         "imf_gb_inflation",
         "rest+http",
         "http://dataservices.imf.org/REST/SDMX_JSON.svc/CompactData/IFS/M.GB.PMP_IX",
-        parser=parse_imf_data
+        parser=parse_imf_data,
     )
 ]
 
@@ -90,15 +61,16 @@ def transformer(data_dict: dict):
         A dictionary containing the transformed dataframes.
     """
 
-    data = data_dict['imf_gb_inflation']
+    data = data_dict["imf_gb_inflation"]
 
     # Create pandas dataframe from the observations
-    data_list = [[obs.get('@TIME_PERIOD'), obs.get('@OBS_VALUE')]
-                 for obs in data['Obs']]
+    data_list = [
+        [obs.get("@TIME_PERIOD"), obs.get("@OBS_VALUE")] for obs in data["Obs"]
+    ]
 
-    df = pd.DataFrame(data_list, columns=['date', 'value'])
+    df = pd.DataFrame(data_list, columns=["date", "value"])
 
-    df = df.set_index(pd.to_datetime(df['date']))['value'].astype('float')
+    df = df.set_index(pd.to_datetime(df["date"]))["value"].astype("float")
 
     res_dict = {"imf_gb_inflation": df}
     return res_dict
@@ -119,27 +91,24 @@ def get_details():
         A `PipeLineDetails` object that contains all of the details for the pipeline.
     """
     # Used csv for test
-    CONNECTOR = os.getenv('CONNECTOR', "csv:/tmp/truflation")
+    CONNECTOR = os.getenv("CONNECTOR", "csv:/tmp/truflation")
 
     if CONNECTOR is None:
         raise Exception("CONNECTOR not found in environment")
 
     exports = [
         ExportDetails(
-            name='imf_gb_inflation',
-            connector=CONNECTOR,
-            key='imf_gb_inflation'
+            name="imf_gb_inflation", connector=CONNECTOR, key="imf_gb_inflation"
         )
     ]
 
-    my_pipeline = PipeLineDetails(name=pipeline_name,
-                                  sources=sources,
-                                  exports=exports,
-                                  cron_schedule=cron_schedule,
-                                  pre_ingestion_function=pre_ingestion_function,
-                                  post_ingestion_function=post_ingestion_function,
-                                  transformer=transformer
-                                  )
+    my_pipeline = PipeLineDetails(
+        name=PIPELINE_NAME,
+        sources=sources,
+        exports=exports,
+        cron_schedule=cron_schedule,
+        transformer=transformer,
+    )
     return my_pipeline
 
 

--- a/examples/imf_data/imf_gb_pipeline.py
+++ b/examples/imf_data/imf_gb_pipeline.py
@@ -1,0 +1,147 @@
+import os
+from typing import Dict
+
+import pandas as pd
+from dotenv import load_dotenv
+
+from truflation.data.export_details import ExportDetails
+from truflation.data.pipeline_details import PipeLineDetails
+from truflation.data.source_details import SourceDetails
+
+load_dotenv()
+
+# Name
+pipeline_name = "IMF GB Inflation"
+
+
+def pre_ingestion_function():
+    """
+    Function to perform operations before the data ingestion phase.
+    This function is called during the pipeline execution before data loading starts.
+
+    Currently, this function only prints out a simple message.
+
+    Returns
+    -------
+    None
+    """
+    print(f'I do this before ingestion')
+
+
+def post_ingestion_function():
+    """
+    Function to perform operations after the data ingestion phase.
+    This function is called during the pipeline execution after all data loading is finished.
+
+    Currently, this function only prints out a simple message.
+
+    Returns
+    -------
+    None
+    """
+    print(f'I do this after ingestion')
+
+
+def parse_imf_data(json_obj: Dict) -> Dict:
+    """
+    Function to parse investing.com json object.
+    Args:
+        json_obj (Dict): investing.com json object.
+    Returns:
+        pd.DataFrame: Parsed dataframe from json.
+    """
+    print(2)
+    return json_obj['CompactData']['DataSet']['Series']
+
+
+sources = [
+    SourceDetails(
+        "imf_gb_inflation",
+        "rest+http",
+        "http://dataservices.imf.org/REST/SDMX_JSON.svc/CompactData/IFS/M.GB.PMP_IX",
+        parser=parse_imf_data
+    )
+]
+
+# Schedule to work every month
+cron_schedule = {
+    "second": "0",
+    "minute": "0",
+    "hour": "0",
+    "day": "1",
+    "month": "1",
+    "year": "*",
+}
+
+
+def transformer(data_dict: dict):
+    """
+    Performs a specific transformation operation on the input dataframes.
+    The transformation is applied on compact data from
+
+    Parameters
+    ----------
+    data_dict : dict
+        A dictionary where the key is the name of the dataframe, and the value is the dataframe itself.
+
+    Returns
+    -------
+    dict
+        A dictionary containing the transformed dataframes.
+    """
+
+    data = data_dict['imf_gb_inflation']
+
+    # Create pandas dataframe from the observations
+    data_list = [[obs.get('@TIME_PERIOD'), obs.get('@OBS_VALUE')]
+                 for obs in data['Obs']]
+
+    df = pd.DataFrame(data_list, columns=['date', 'value'])
+
+    df = df.set_index(pd.to_datetime(df['date']))['value'].astype('float')
+
+    res_dict = {"imf_gb_inflation": df}
+    return res_dict
+
+
+def get_details():
+    """
+    Retrieves the details of a pipeline and returns a `PipeLineDetails` object.
+
+    This function loads environment variables, defines sources and exports,
+    and creates a `PipeLineDetails` object to represent the pipeline.
+    The pipeline includes pre-ingestion and post-ingestion functions,
+    a transformer for data transformation, and a cron schedule for pipeline execution.
+
+    Returns
+    -------
+    PipeLineDetails
+        A `PipeLineDetails` object that contains all of the details for the pipeline.
+    """
+    # Used csv for test
+    CONNECTOR = os.getenv('CONNECTOR', "csv:/tmp/truflation")
+
+    if CONNECTOR is None:
+        raise Exception("CONNECTOR not found in environment")
+
+    exports = [
+        ExportDetails(
+            name='imf_gb_inflation',
+            connector=CONNECTOR,
+            key='imf_gb_inflation'
+        )
+    ]
+
+    my_pipeline = PipeLineDetails(name=pipeline_name,
+                                  sources=sources,
+                                  exports=exports,
+                                  cron_schedule=cron_schedule,
+                                  pre_ingestion_function=pre_ingestion_function,
+                                  post_ingestion_function=post_ingestion_function,
+                                  transformer=transformer
+                                  )
+    return my_pipeline
+
+
+if __name__ == "__main__":
+    get_details()

--- a/examples/imf_data/unit_tests/sample_response.json
+++ b/examples/imf_data/unit_tests/sample_response.json
@@ -1,0 +1,56 @@
+{
+  "CompactData": {
+    "@xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+    "@xmlns:xsd": "http://www.w3.org/2001/XMLSchema",
+    "@xsi:schemaLocation": "http://www.SDMX.org/resources/SDMXML/schemas/v2_0/message https://registry.sdmx.org/schemas/v2_0/SDMXMessage.xsd http://dataservices.imf.org/compact/IFS http://dataservices.imf.org/compact/IFS.xsd",
+    "@xmlns": "http://www.SDMX.org/resources/SDMXML/schemas/v2_0/message",
+    "Header": {
+      "ID": "77d5ae85-49cc-4db7-a3b4-2435314dd7cc",
+      "Test": "false",
+      "Prepared": "2024-03-25T14:51:33",
+      "Sender": {
+        "@id": "1C0",
+        "Name": {
+          "@xml:lang": "en",
+          "#text": "IMF"
+        },
+        "Contact": {
+          "URI": "http://www.imf.org",
+          "Telephone": "+ 1 (202) 623-6220"
+        }
+      },
+      "Receiver": {
+        "@id": "ZZZ"
+      },
+      "DataSetID": "IFS"
+    },
+    "DataSet": {
+      "@xmlns": "http://dataservices.imf.org/compact/IFS",
+      "Series": {
+        "@FREQ": "M",
+        "@REF_AREA": "GB",
+        "@INDICATOR": "PMP_IX",
+        "@UNIT_MULT": "0",
+        "@BASE_YEAR": "2010=100",
+        "@TIME_FORMAT": "P1M",
+        "Obs": [ {
+            "@TIME_PERIOD": "2018-11",
+            "@OBS_VALUE": "108.12133072407"
+          }, {
+            "@TIME_PERIOD": "2018-12",
+            "@OBS_VALUE": "106.947162426614"
+          }, {
+            "@TIME_PERIOD": "2019-01",
+            "@OBS_VALUE": "104.794520547945"
+          }, {
+            "@TIME_PERIOD": "2019-05",
+            "@OBS_VALUE": "108.12133072407"
+          }, {
+            "@TIME_PERIOD": "2019-06",
+            "@OBS_VALUE": "107.3385518591"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/examples/imf_data/unit_tests/test_pipeline.py
+++ b/examples/imf_data/unit_tests/test_pipeline.py
@@ -1,0 +1,31 @@
+import pytest
+import responses
+from truflation.data.pipeline import Pipeline
+from ..imf_gb_pipeline import get_details
+import logging
+from pathlib import Path
+from pandas import read_csv
+import numpy
+from typing import Mapping, Any
+import os
+import json
+
+
+def load_response(response_name: str) -> Mapping[str, Any]:
+    with open(Path(os.path.dirname(__file__)) / response_name, "r") as response:
+        return json.load(response)
+
+
+@responses.activate
+def test_pipeline(caplog):
+    resp = responses.get(
+        "http://dataservices.imf.org/REST/SDMX_JSON.svc/CompactData/IFS/M.GB.PMP_IX",
+        json=load_response("sample_response.json"),
+    )
+    pipeline_details = get_details()
+    my_pipeline = Pipeline(pipeline_details)
+    my_pipeline.ingest()
+    csv_export = my_pipeline.exports[0]
+    df = read_csv(Path(csv_export.writer.path_root) / csv_export.name)
+    assert resp.call_count == 1
+    assert len(df) == 5


### PR DESCRIPTION
### What

- add new ignestor (with pipeline) for [IMF GB inflation rate](https://datahelp.imf.org/knowledgebase/articles/1968408-how-to-use-the-api-python-and-r)

### console output

<details><summary>Hidden output</summary>

`imf_gb_pipeline.py `
```
####################   Ingesting...   ############################

####################   Pre Ingestion Function...   ###############
I do this before ingestion

####################   Loading...   ##############################
DEBUG:truflation.data.general_loader:reading http://dataservices.imf.org/REST/SDMX_JSON.svc/CompactData/IFS/M.GB.PMP_IX
DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): dataservices.imf.org:80
DEBUG:urllib3.connectionpool:http://dataservices.imf.org:80 "GET /REST/SDMX_JSON.svc/CompactData/IFS/M.GB.PMP_IX HTTP/1.1" 200 5865
2

####################   Transforming...   #########################

####################   Exporting...   ############################

####################   Post Ingestion Function...   ##############
I do this after ingestion
ingestor IMF GB Inflation ran successfully

```

`cat /tmp/truflation/imf_gb_inflation `
```csv
date,value
1980-01-01,45.2190999645466
1980-02-01,45.7904604334127
...
```

</details>
